### PR TITLE
Update travis php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: php
 
-php: 
-  - hhvm
-  - nightly
-  - 7.0
-  - 5.6
-  - 5.5
-  - 5.4
+php:
+  - 5.3.3
   - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
 
 before_install: 
   - sudo apt-get install nodejs


### PR DESCRIPTION
We actually have to testa against PHP 5.3.3 since that is the version we're targeting in `composer.json`.