### PR TITLE
Fix ios category id naming issue and add support for send_rate

### DIFF
--- a/src/main/php/Gomoob/Pushwoosh/Model/Notification/IOS.php
+++ b/src/main/php/Gomoob/Pushwoosh/Model/Notification/IOS.php
@@ -103,7 +103,7 @@ class IOS implements \JsonSerializable
     
         isset($this->apnsTrimContent) ? $json['apns_trim_content'] = intval($this->apnsTrimContent) : false;
         isset($this->badges) ? $json['ios_badges'] = $this->badges : false;
-        isset($this->categoryId) ? $json['category_id'] = $this->categoryId : false;
+        isset($this->categoryId) ? $json['ios_category_id'] = $this->categoryId : false;
         isset($this->rootParams) ? $json['ios_root_params'] = $this->rootParams : false;
         isset($this->sound) ? $json['ios_sound'] = $this->sound : false;
         isset($this->ttl) ? $json['ios_ttl'] = $this->ttl : false;

--- a/src/main/php/Gomoob/Pushwoosh/Model/Notification/Notification.php
+++ b/src/main/php/Gomoob/Pushwoosh/Model/Notification/Notification.php
@@ -516,7 +516,7 @@ class Notification implements \JsonSerializable
         $json['send_date'] = is_string($this->sendDate) ? $this->sendDate : $this->sendDate->format('Y-m-d H:i');
     
         // Optional parameters
-	isset($this->sendRate)? $json['send_rate'] = $this->sendRate : false;
+        isset($this->sendRate)? $json['send_rate'] = $this->sendRate : false;
         isset($this->content) ? $json['content'] = $this->content : false;
         isset($this->data) ? $json['data'] = $this->data : false;
         isset($this->devices) ? $json['devices'] = $this->devices : false;

--- a/src/main/php/Gomoob/Pushwoosh/Model/Notification/Notification.php
+++ b/src/main/php/Gomoob/Pushwoosh/Model/Notification/Notification.php
@@ -118,6 +118,9 @@ class Notification implements \JsonSerializable
     // TODO: DOCUMENT ME !
     private $ignoreUserTimezone = true;
 
+    // TODO: DOCUMENT ME !
+    private $sendRate;
+
     /**
      * The object which contains specific Pushwoosh notification informations for IOS (Apple Push Notification Service).
      *
@@ -513,6 +516,7 @@ class Notification implements \JsonSerializable
         $json['send_date'] = is_string($this->sendDate) ? $this->sendDate : $this->sendDate->format('Y-m-d H:i');
     
         // Optional parameters
+	isset($this->sendRate)? $json['send_rate'] = $this->sendRate : false;
         isset($this->content) ? $json['content'] = $this->content : false;
         isset($this->data) ? $json['data'] = $this->data : false;
         isset($this->devices) ? $json['devices'] = $this->devices : false;
@@ -722,6 +726,14 @@ class Notification implements \JsonSerializable
     public function setIgnoreUserTimezone($ignoreUserTimezone)
     {
         $this->ignoreUserTimezone = $ignoreUserTimezone;
+
+        return $this;
+    }
+
+    // TODO: DOCUMENT ME !
+    public function setSendRate($sendRate)
+    {
+        $this->sendRate = $sendRate;
 
         return $this;
     }


### PR DESCRIPTION

http://docs.pushwoosh.com/docs/createmessage

**Example:**

"ios_category_id": "1",       // Optional. Integer. iOS8 category ID from Pushwoosh
"send_rate": 100, // Throttling. Valid values are from 100 to 1000 pushes/second.