### PR TITLE
Fix field name for applications group in json request

### DIFF
--- a/src/main/php/Gomoob/Pushwoosh/Model/Request/CreateMessageRequest.php
+++ b/src/main/php/Gomoob/Pushwoosh/Model/Request/CreateMessageRequest.php
@@ -131,7 +131,7 @@ class CreateMessageRequest extends AbstractRequest
     
         $json = [
             'application' => $this->application,
-            'applicationsGroup' => $this->applicationsGroup,
+            'applications_group' => $this->applicationsGroup,
             'auth' => $this->auth,
             'notifications' => []
         ];


### PR DESCRIPTION
Fix field name for applications group in json request from applicationsGroup to applications_group due to official documentation: http://docs.pushwoosh.com/docs/createmessage