### PR TITLE
Revert "Add support for NOTIN with ListCondition"

### DIFF
--- a/src/main/php/Gomoob/Pushwoosh/Model/Condition/ListCondition.php
+++ b/src/main/php/Gomoob/Pushwoosh/Model/Condition/ListCondition.php
@@ -50,19 +50,4 @@ class ListCondition extends AbstractCondition
         return $this;
 
     }
-    
-     /**
-     * Apply an NOTIN operator to a specified operand value.
-     *
-     * @param string[] $values the string values used to build in NOTIN value set.
-     *
-     * @return \Gomoob\Pushwoosh\Model\Condition\ListCondition this instance.
-     */
-    public function notin($values)
-    {
-        $this->operator = 'NOTIN';
-        $this->operand = $values;
-    
-        return $this;
-    }
 }


### PR DESCRIPTION
Reverts gomoob/php-pushwoosh#54

Oups, I merged this but I'm not sure `NOTIN` should be supported with the `LIST` condition. In the official Remote Guide http://docs.pushwoosh.com/docs/createmessage they only indicate that `IN` operator is supported for the `LIST` condition. 

So are you sure `NOTIN` is supported, If yes could you provide a link which shows this ? 