### PR TITLE
Missing campaign data in api request

### DIFF
--- a/src/main/php/Gomoob/Pushwoosh/Model/Notification/Notification.php
+++ b/src/main/php/Gomoob/Pushwoosh/Model/Notification/Notification.php
@@ -673,7 +673,11 @@ class Notification implements \JsonSerializable
         isset($this->richPageId) ? $json['rich_page_id'] = $this->richPageId : false;
         isset($this->sendRate)? $json['send_rate'] = $this->sendRate : false;
         isset($this->timezone)? $json['timezone'] = $this->timezone : false;
-    
+
+        if (isset($this->campain)) {
+            $json['campaign'] = $this->campain;
+        }
+
         if (isset($this->conditions)) {
             $conditionsArray = [];
     

--- a/src/test/php/Gomoob/Pushwoosh/Model/Notification/NotificationTest.php
+++ b/src/test/php/Gomoob/Pushwoosh/Model/Notification/NotificationTest.php
@@ -564,6 +564,7 @@ class NotificationTest extends TestCase
                     ->setCount(3)
                     ->setType('Tile')
             )
+            ->setCampain('CAMPAIGN')
             ->jsonSerialize();
 
         // Test the generic properties
@@ -610,6 +611,7 @@ class NotificationTest extends TestCase
         $this->assertSame('value0', $array['conditions'][2][2][0]);
         $this->assertSame('value1', $array['conditions'][2][2][1]);
         $this->assertSame('value2', $array['conditions'][2][2][2]);
+        $this->assertSame('CAMPAIGN', $array['campaign']);
 
         // Test the ADM parameters
         $this->assertSame('http://example.com/banner.png', $array['adm_banner']);

--- a/src/test/php/Gomoob/Pushwoosh/Model/Notification/NotificationTest.php
+++ b/src/test/php/Gomoob/Pushwoosh/Model/Notification/NotificationTest.php
@@ -568,7 +568,7 @@ class NotificationTest extends TestCase
             ->jsonSerialize();
 
         // Test the generic properties
-        $this->assertCount(63, $array);
+        $this->assertCount(64, $array);
         $this->assertSame('now', $array['send_date']);
         $this->assertSame('America/New_York', $array['timezone']);
         $this->assertTrue($array['ignore_user_timezone']);


### PR DESCRIPTION
PR fixes the missing field 'campaign' in the createMessage api request.