### PR TITLE
Allow to use own url for API server

### DIFF
--- a/src/main/php/Gomoob/Pushwoosh/Client/CURLClient.php
+++ b/src/main/php/Gomoob/Pushwoosh/Client/CURLClient.php
@@ -36,6 +36,8 @@ class CURLClient implements ICURLClient
     
     /**
      * Creates a new CURL client instance.
+     *
+     * @param $url string - API server url
      */
     public function __construct($url = '')
     {

--- a/src/main/php/Gomoob/Pushwoosh/Client/CURLClient.php
+++ b/src/main/php/Gomoob/Pushwoosh/Client/CURLClient.php
@@ -28,11 +28,22 @@ class CURLClient implements ICURLClient
     private $curlRequest;
     
     /**
+     * API server url
+     *
+     * @var string
+     */
+    private $apiUrl = 'https://cp.pushwoosh.com/json/1.3/';
+    
+    /**
      * Creates a new CURL client instance.
      */
-    public function __construct()
+    public function __construct($url = '')
     {
         $this->curlRequest = new CurlRequest();
+        
+        if(!empty($url)) {
+            $this->apiUrl = $url;
+        }
     }
     
     /**
@@ -50,7 +61,7 @@ class CURLClient implements ICURLClient
      */
     public function pushwooshCall($method, array $data)
     {
-        $url = 'https://cp.pushwoosh.com/json/1.3/' . $method;
+        $url = $this->apiUrl . $method;
         $request = json_encode(['request' => $data]);
 
         $this->curlRequest->init($url);

--- a/src/main/php/Gomoob/Pushwoosh/Client/Pushwoosh.php
+++ b/src/main/php/Gomoob/Pushwoosh/Client/Pushwoosh.php
@@ -76,20 +76,22 @@ class Pushwoosh implements IPushwoosh
 
     /**
      * Create a new instance of the Pushwoosh client.
+     * @param $url string - API server url
      */
-    public function __construct()
+    public function __construct($url = '')
     {
-        $this->cURLClient = new CURLClient();
+        $this->cURLClient = new CURLClient($url);
     }
 
     /**
      * Utility function used to create a new instance of the Pushwoosh client.
      *
+     * @param $url string - API server url
      * @return \Gomoob\Pushwoosh\Client\Pushwoosh the new created instance.
      */
-    public static function create()
+    public static function create($url = '')
     {
-        return new Pushwoosh();
+        return new Pushwoosh($url);
     }
 
     /**


### PR DESCRIPTION
This patch allow to use own url for API server. It is needed when url is changed to something like https://your-company.pushwoosh.com instead of https://cp.pushwoosh.com for enterprise contracts