### PR TITLE
Support chrome_button_text and chrome_button_url

### DIFF
--- a/src/main/php/Gomoob/Pushwoosh/Model/Notification/Chrome.php
+++ b/src/main/php/Gomoob/Pushwoosh/Model/Notification/Chrome.php
@@ -48,28 +48,28 @@ class Chrome implements \JsonSerializable
      *
      * @var string
      */
-    private $buttonText1;
+    private $buttonTextOne;
 
     /**
      * Url of the first button
      *
      * @var
      */
-    private $buttonUrl1;
+    private $buttonUrlOne;
 
     /**
      * Text of the second button
      *
      * @var string
      */
-    private $buttonText2;
+    private $buttonTextTwo;
 
     /**
      * Url of the second button
      *
      * @var
      */
-    private $buttonUrl2;
+    private $buttonUrlTwo;
 
     /**
      * Utility function used to create a new Chrome instance.
@@ -126,9 +126,9 @@ class Chrome implements \JsonSerializable
      *
      * @return string $text The text of the first button.
      */
-    public function getButtonText1()
+    public function getButtonTextOne()
     {
-        return $this->buttonText1;
+        return $this->buttonTextOne;
     }
 
     /**
@@ -136,9 +136,9 @@ class Chrome implements \JsonSerializable
      *
      * @return string $url The url of the first button.*
      */
-    public function getButtonUrl1($url)
+    public function getButtonUrlOne($url)
     {
-        return $this->buttonUrl1;
+        return $this->buttonUrlOne;
     }
 
     /**
@@ -146,9 +146,9 @@ class Chrome implements \JsonSerializable
      *
      * @return string $text The text of the second button.*
      */
-    public function getButtonText2()
+    public function getButtonTextTwo()
     {
-        return $this->buttonText2;
+        return $this->buttonTextTwo;
     }
 
     /**
@@ -156,9 +156,9 @@ class Chrome implements \JsonSerializable
      *
      * @return string $url The url of the second button.
      */
-    public function getButtonUrl2()
+    public function getButtonUrlTwo()
     {
-        return $this->buttonUrl2;
+        return $this->buttonUrlTwo;
     }
 
     /**
@@ -172,10 +172,10 @@ class Chrome implements \JsonSerializable
         isset($this->icon) ? $json['chrome_icon'] = $this->icon : false;
         isset($this->title) ? $json['chrome_title'] = $this->title : false;
         isset($this->image) ? $json['chrome_image'] = $this->image : false;
-        isset($this->buttonText1) ? $json['chrome_button_text1'] = $this->buttonText1 : false;
-        isset($this->buttonUrl1) ? $json['chrome_button_url1'] = $this->buttonUrl1 : false;
-        isset($this->buttonText2) ? $json['chrome_button_text2'] = $this->buttonText2 : false;
-        isset($this->buttonUrl2) ? $json['chrome_button_url2'] = $this->buttonUrl2 : false;
+        isset($this->buttonTextOne) ? $json['chrome_button_text1'] = $this->buttonTextOne : false;
+        isset($this->buttonUrlOne) ? $json['chrome_button_url1'] = $this->buttonUrlOne : false;
+        isset($this->buttonTextTwo) ? $json['chrome_button_text2'] = $this->buttonTextTwo : false;
+        isset($this->buttonUrlTwo) ? $json['chrome_button_url2'] = $this->buttonUrlTwo : false;
 
         return $json;
 
@@ -244,9 +244,9 @@ class Chrome implements \JsonSerializable
      *
      * @return \Gomoob\Pushwoosh\Model\Notification\Chrome this instance.
      */
-    public function setButtonText1($text)
+    public function setButtonTextOne($text)
     {
-        $this->buttonText1 = $text;
+        $this->buttonTextOne = $text;
 
         return $this;
     }
@@ -258,9 +258,9 @@ class Chrome implements \JsonSerializable
      *
      * @return \Gomoob\Pushwoosh\Model\Notification\Chrome this instance.
      */
-    public function setButtonUrl1($url)
+    public function setButtonUrlOne($url)
     {
-        $this->buttonUrl1 = $url;
+        $this->buttonUrlOne = $url;
 
         return $this;
     }
@@ -272,9 +272,9 @@ class Chrome implements \JsonSerializable
      *
      * @return \Gomoob\Pushwoosh\Model\Notification\Chrome this instance.
      */
-    public function setButtonText2($text)
+    public function setButtonTextTwo($text)
     {
-        $this->buttonText2 = $text;
+        $this->buttonTextTwo = $text;
 
         return $this;
     }
@@ -286,9 +286,9 @@ class Chrome implements \JsonSerializable
      *
      * @return \Gomoob\Pushwoosh\Model\Notification\Chrome this instance.
      */
-    public function setButtonUrl2($url)
+    public function setButtonUrlTwo($url)
     {
-        $this->buttonUrl2 = $url;
+        $this->buttonUrlTwo = $url;
 
         return $this;
     }

--- a/src/main/php/Gomoob/Pushwoosh/Model/Notification/Chrome.php
+++ b/src/main/php/Gomoob/Pushwoosh/Model/Notification/Chrome.php
@@ -41,8 +41,36 @@ class Chrome implements \JsonSerializable
      *
      * @var string
      */
-    private $image;    
-    
+    private $image;
+
+    /**
+     * Text of the first button
+     *
+     * @var string
+     */
+    private $buttonText1;
+
+    /**
+     * Url of the first button
+     *
+     * @var
+     */
+    private $buttonUrl1;
+
+    /**
+     * Text of the second button
+     *
+     * @var string
+     */
+    private $buttonText2;
+
+    /**
+     * Url of the second button
+     *
+     * @var
+     */
+    private $buttonUrl2;
+
     /**
      * Utility function used to create a new Chrome instance.
      *
@@ -62,7 +90,7 @@ class Chrome implements \JsonSerializable
     {
         return $this->gcmTtl;
     }
-    
+
     /**
      * Gets the full path URL to the icon, or the path to the file in resources of the extension.
      *
@@ -72,7 +100,7 @@ class Chrome implements \JsonSerializable
     {
         return $this->icon;
     }
-    
+
     /**
      * Gets the header of the message.
      *
@@ -91,24 +119,68 @@ class Chrome implements \JsonSerializable
     public function getImage()
     {
         return $this->image;
-    }    
-    
+    }
+
+    /**
+     * Gets the text of the first button.
+     *
+     * @return string $text The text of the first button.
+     */
+    public function getButtonText1()
+    {
+        return $this->buttonText1;
+    }
+
+    /**
+     * Gets the url of the first button.
+     *
+     * @return string $url The url of the first button.*
+     */
+    public function getButtonUrl1($url)
+    {
+        return $this->buttonUrl1;
+    }
+
+    /**
+     * Gets the text of the second button.
+     *
+     * @return string $text The text of the second button.*
+     */
+    public function getButtonText2()
+    {
+        return $this->buttonText2;
+    }
+
+    /**
+     * Gets the url of the second button.
+     *
+     * @return string $url The url of the second button.
+     */
+    public function getButtonUrl2()
+    {
+        return $this->buttonUrl2;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function jsonSerialize()
     {
         $json = [];
-    
+
         isset($this->gcmTtl) ? $json['chrome_gcm_ttl'] = $this->gcmTtl : false;
         isset($this->icon) ? $json['chrome_icon'] = $this->icon : false;
         isset($this->title) ? $json['chrome_title'] = $this->title : false;
         isset($this->image) ? $json['chrome_image'] = $this->image : false;
-    
+        isset($this->buttonText1) ? $json['chrome_button_text1'] = $this->buttonText1 : false;
+        isset($this->buttonUrl1) ? $json['chrome_button_url1'] = $this->buttonUrl1 : false;
+        isset($this->buttonText2) ? $json['chrome_button_text2'] = $this->buttonText2 : false;
+        isset($this->buttonUrl2) ? $json['chrome_button_url2'] = $this->buttonUrl2 : false;
+
         return $json;
-    
+
     }
-    
+
     /**
      * Sets the time to live parameter - the maximum lifespan of a message in seconds.
      *
@@ -119,10 +191,10 @@ class Chrome implements \JsonSerializable
     public function setGcmTtl($gcmTtl)
     {
         $this->gcmTtl = $gcmTtl;
-    
+
         return $this;
     }
-    
+
     /**
      * Sets the full path URL to the icon, or the path to the file in resources of the extension.
      *
@@ -133,10 +205,10 @@ class Chrome implements \JsonSerializable
     public function setIcon($icon)
     {
         $this->icon = $icon;
-    
+
         return $this;
     }
-    
+
     /**
      * Sets the header of the message.
      *
@@ -147,7 +219,7 @@ class Chrome implements \JsonSerializable
     public function setTitle($title)
     {
         $this->title = $title;
-    
+
         return $this;
     }
 
@@ -161,7 +233,63 @@ class Chrome implements \JsonSerializable
     public function setImage($image)
     {
         $this->image = $image;
-    
+
         return $this;
-    }    
+    }
+
+    /**
+     * Sets the text of the first button.
+     *
+     * @param string $text The text of the first button.
+     *
+     * @return \Gomoob\Pushwoosh\Model\Notification\Chrome this instance.
+     */
+    public function setButtonText1($text)
+    {
+        $this->buttonText1 = $text;
+
+        return $this;
+    }
+
+    /**
+     * Sets the url of the first button.
+     *
+     * @param string $url The url of the first button.
+     *
+     * @return \Gomoob\Pushwoosh\Model\Notification\Chrome this instance.
+     */
+    public function setButtonUrl1($url)
+    {
+        $this->buttonUrl1 = $url;
+
+        return $this;
+    }
+
+    /**
+     * Sets the text of the second button.
+     *
+     * @param string $text The text of the second button.
+     *
+     * @return \Gomoob\Pushwoosh\Model\Notification\Chrome this instance.
+     */
+    public function setButtonText2($text)
+    {
+        $this->buttonText2 = $text;
+
+        return $this;
+    }
+
+    /**
+     * Sets the url of the second button.
+     *
+     * @param string $url The url of the second button.
+     *
+     * @return \Gomoob\Pushwoosh\Model\Notification\Chrome this instance.
+     */
+    public function setButtonUrl2($url)
+    {
+        $this->buttonUrl2 = $url;
+
+        return $this;
+    }
 }

--- a/src/main/php/Gomoob/Pushwoosh/Model/Notification/Chrome.php
+++ b/src/main/php/Gomoob/Pushwoosh/Model/Notification/Chrome.php
@@ -136,7 +136,7 @@ class Chrome implements \JsonSerializable
      *
      * @return string $url The url of the first button.*
      */
-    public function getButtonUrlOne($url)
+    public function getButtonUrlOne()
     {
         return $this->buttonUrlOne;
     }

--- a/src/test/php/Gomoob/Pushwoosh/Model/Notification/ChromeTest.php
+++ b/src/test/php/Gomoob/Pushwoosh/Model/Notification/ChromeTest.php
@@ -64,8 +64,48 @@ class ChromeTest extends TestCase
         $chrome = new Chrome();
         $this->assertSame($chrome, $chrome->setImage('Image'));
         $this->assertSame('Image', $chrome->getImage());
-    }    
-    
+    }
+
+    /**
+     * Test method for the <code>#getButtonTextOne()</code> and <code>#setButtonTextOne($text)</code> functions.
+     */
+    public function testGetButtonTextOne()
+    {
+        $chrome = new Chrome();
+        $this->assertSame($chrome, $chrome->setButtonTextOne('ButtonTextOne'));
+        $this->assertSame('ButtonTextOne', $chrome->getButtonTextOne());
+    }
+
+    /**
+     * Test method for the <code>#getButtonUrlOne()</code> and <code>#setButtonUrlOne($url)</code> functions.
+     */
+    public function testGetButtonUrlOne()
+    {
+        $chrome = new Chrome();
+        $this->assertSame($chrome, $chrome->setButtonUrlOne('ButtonUrlOne'));
+        $this->assertSame('ButtonUrlOne', $chrome->getButtonUrlOne());
+    }
+
+    /**
+     * Test method for the <code>#getButtonTextTwo()</code> and <code>#setButtonTextTwo($text)</code> functions.
+     */
+    public function testGetButtonTextTwo()
+    {
+        $chrome = new Chrome();
+        $this->assertSame($chrome, $chrome->setButtonTextTwo('ButtonTextTwo'));
+        $this->assertSame('ButtonTextTwo', $chrome->getButtonTextTwo());
+    }
+
+    /**
+     * Test method for the <code>#getButtonUrlTwo()</code> and <code>#setButtonUrlTwo($url)</code> functions.
+     */
+    public function testGetButtonUrlTwo()
+    {
+        $chrome = new Chrome();
+        $this->assertSame($chrome, $chrome->setButtonUrlTwo('ButtonUrlTwo'));
+        $this->assertSame('ButtonUrlTwo', $chrome->getButtonUrlTwo());
+    }
+
     /**
      * Test method for the <code>#jsonSerialize()</code> function.
      */

--- a/src/test/php/Gomoob/Pushwoosh/Model/Notification/ChromeTest.php
+++ b/src/test/php/Gomoob/Pushwoosh/Model/Notification/ChromeTest.php
@@ -76,12 +76,20 @@ class ChromeTest extends TestCase
             ->setIcon('icon')
             ->setTitle('Title')
             ->setImage('Image')
+            ->setButtonText1('ButtonText1')
+            ->setButtonUrl1('ButtonUrl1')
+            ->setButtonText2('ButtonText2')
+            ->setButtonUrl2('ButtonUrl2')
             ->jsonSerialize();
         
-        $this->assertCount(4, $array);
+        $this->assertCount(8, $array);
         $this->assertSame(3600, $array['chrome_gcm_ttl']);
         $this->assertSame('icon', $array['chrome_icon']);
         $this->assertSame('Title', $array['chrome_title']);
         $this->assertSame('Image', $array['chrome_image']);
+        $this->assertSame('ButtonText1', $array['chrome_button_text1']);
+        $this->assertSame('ButtonUrl1', $array['chrome_button_url1']);
+        $this->assertSame('ButtonText2', $array['chrome_button_text2']);
+        $this->assertSame('ButtonUrl2', $array['chrome_button_url2']);
     }
 }

--- a/src/test/php/Gomoob/Pushwoosh/Model/Notification/ChromeTest.php
+++ b/src/test/php/Gomoob/Pushwoosh/Model/Notification/ChromeTest.php
@@ -76,10 +76,10 @@ class ChromeTest extends TestCase
             ->setIcon('icon')
             ->setTitle('Title')
             ->setImage('Image')
-            ->setButtonText1('ButtonText1')
-            ->setButtonUrl1('ButtonUrl1')
-            ->setButtonText2('ButtonText2')
-            ->setButtonUrl2('ButtonUrl2')
+            ->setButtonTextOne('ButtonTextOne')
+            ->setButtonUrlOne('ButtonUrlOne')
+            ->setButtonTextTwo('ButtonTextTwo')
+            ->setButtonUrlTwo('ButtonUrlTwo')
             ->jsonSerialize();
         
         $this->assertCount(8, $array);
@@ -87,9 +87,9 @@ class ChromeTest extends TestCase
         $this->assertSame('icon', $array['chrome_icon']);
         $this->assertSame('Title', $array['chrome_title']);
         $this->assertSame('Image', $array['chrome_image']);
-        $this->assertSame('ButtonText1', $array['chrome_button_text1']);
-        $this->assertSame('ButtonUrl1', $array['chrome_button_url1']);
-        $this->assertSame('ButtonText2', $array['chrome_button_text2']);
-        $this->assertSame('ButtonUrl2', $array['chrome_button_url2']);
+        $this->assertSame('ButtonTextOne', $array['chrome_button_text1']);
+        $this->assertSame('ButtonUrlOne', $array['chrome_button_url1']);
+        $this->assertSame('ButtonTextTwo', $array['chrome_button_text2']);
+        $this->assertSame('ButtonUrlTwo', $array['chrome_button_url2']);
     }
 }

--- a/src/test/php/Gomoob/Pushwoosh/Model/Notification/NotificationTest.php
+++ b/src/test/php/Gomoob/Pushwoosh/Model/Notification/NotificationTest.php
@@ -542,10 +542,10 @@ class NotificationTest extends TestCase
                     ->setIcon('icon')
                     ->setTitle('Title')
                     ->setImage('Image')
-                    ->setButtonText1('ButtonText1')
-                    ->setButtonUrl1('ButtonUrl1')
-                    ->setButtonText2('ButtonText2')
-                    ->setButtonUrl2('ButtonUrl2')
+                    ->setButtonTextOne('ButtonTextOne')
+                    ->setButtonUrlOne('ButtonUrlOne')
+                    ->setButtonTextTwo('ButtonTextTwo')
+                    ->setButtonUrlTwo('ButtonUrlTwo')
             )
             ->setIOS(
                 IOS::create()
@@ -672,10 +672,10 @@ class NotificationTest extends TestCase
         $this->assertSame('icon', $array['chrome_icon']);
         $this->assertSame('Title', $array['chrome_title']);
         $this->assertSame('Image', $array['chrome_image']);
-        $this->assertSame('ButtonText1', $array['chrome_button_text1']);
-        $this->assertSame('ButtonUrl1', $array['chrome_button_url1']);
-        $this->assertSame('ButtonText2', $array['chrome_button_text2']);
-        $this->assertSame('ButtonUrl2', $array['chrome_button_url2']);
+        $this->assertSame('ButtonTextOne', $array['chrome_button_text1']);
+        $this->assertSame('ButtonUrlOne', $array['chrome_button_url1']);
+        $this->assertSame('ButtonTextTwo', $array['chrome_button_text2']);
+        $this->assertSame('ButtonUrlTwo', $array['chrome_button_url2']);
 
         // Test IOS parameters
         $this->assertSame(1, $array['apns_trim_content']);

--- a/src/test/php/Gomoob/Pushwoosh/Model/Notification/NotificationTest.php
+++ b/src/test/php/Gomoob/Pushwoosh/Model/Notification/NotificationTest.php
@@ -542,6 +542,10 @@ class NotificationTest extends TestCase
                     ->setIcon('icon')
                     ->setTitle('Title')
                     ->setImage('Image')
+                    ->setButtonText1('ButtonText1')
+                    ->setButtonUrl1('ButtonUrl1')
+                    ->setButtonText2('ButtonText2')
+                    ->setButtonUrl2('ButtonUrl2')
             )
             ->setIOS(
                 IOS::create()
@@ -590,7 +594,7 @@ class NotificationTest extends TestCase
             ->jsonSerialize();
 
         // Test the generic properties
-        $this->assertCount(65, $array);
+        $this->assertCount(69, $array);
         $this->assertSame('now', $array['send_date']);
         $this->assertSame('America/New_York', $array['timezone']);
         $this->assertTrue($array['ignore_user_timezone']);
@@ -668,6 +672,10 @@ class NotificationTest extends TestCase
         $this->assertSame('icon', $array['chrome_icon']);
         $this->assertSame('Title', $array['chrome_title']);
         $this->assertSame('Image', $array['chrome_image']);
+        $this->assertSame('ButtonText1', $array['chrome_button_text1']);
+        $this->assertSame('ButtonUrl1', $array['chrome_button_url1']);
+        $this->assertSame('ButtonText2', $array['chrome_button_text2']);
+        $this->assertSame('ButtonUrl2', $array['chrome_button_url2']);
 
         // Test IOS parameters
         $this->assertSame(1, $array['apns_trim_content']);


### PR DESCRIPTION
Add support 
```
  “chrome_button_text1”: “1“, // optional
  “chrome_button_url1”: “button1_url“, // optional, ignored if chrome_button_text1 is not set
  “chrome_button_text2”: “2“, // optional
  “chrome_button_url2”: “button2_url”, // optional, ignored if chrome_button_text2 is not set 
          
```
http://docs.pushwoosh.com/docs/createmessage